### PR TITLE
Added profiler and PlatformApplication is now storing events

### DIFF
--- a/DXR-Project/Application/Generic/GenericApplication.h
+++ b/DXR-Project/Application/Generic/GenericApplication.h
@@ -69,6 +69,14 @@ public:
 
 	virtual Bool Init() = 0;
 
+	/*
+	* Events gets stored and is processed in this function. This is because events sometimes are sent
+	* from different functions than PollPlatformEvents, For example GenericWindow::ToggleFullscreen. This
+	* makes sure that all events are processed at one time.
+	*/
+
+	virtual void Tick() = 0;
+
 	virtual void SetCursor(GenericCursor* Cursor)	= 0;
 	virtual GenericCursor* GetCursor() const		= 0;
 

--- a/DXR-Project/Application/Generic/GenericOutputDevice.h
+++ b/DXR-Project/Application/Generic/GenericOutputDevice.h
@@ -22,11 +22,12 @@ class GenericOutputDevice
 public:
 	virtual ~GenericOutputDevice() = default;
 
-	virtual void Print(const std::string& Message) = 0;
+	virtual void Print(const std::string& Message)	= 0;
+	
 	virtual void Clear() = 0;
 
-	virtual void SetTitle(const std::string& Title) = 0;
-	virtual void SetColor(EConsoleColor Color) = 0;
+	virtual void SetTitle(const std::string& Title)	= 0;
+	virtual void SetColor(EConsoleColor Color)		= 0;
 
 	static GenericOutputDevice* Make()
 	{

--- a/DXR-Project/Core.h
+++ b/DXR-Project/Core.h
@@ -78,6 +78,16 @@
 #define MULTILINE_STRING(...) #__VA_ARGS__
 
 /*
+* Function signature as a const Char* string
+*/
+
+#ifdef COMPILER_VISUAL_STUDIO
+	#define __FUNCTION_SIG__ __FUNCTION__
+#else
+	#define __FUNCTION_SIG__ __PRETTY_FUNCTION__
+#endif
+
+/*
 * Disable some warnings
 */
 

--- a/DXR-Project/D3D12/D3D12CommandContext.cpp
+++ b/DXR-Project/D3D12/D3D12CommandContext.cpp
@@ -9,7 +9,9 @@
 #include "D3D12ShaderCompiler.h"
 #include "D3D12Shader.h"
 
-#include <pix3.h>
+#if D3D12_ENABLE_PIX_MARKERS
+	#include <pix3.h>
+#endif
 
 /*
 * D3D12ShaderDescriptorTableState

--- a/DXR-Project/D3D12/D3D12Device.h
+++ b/DXR-Project/D3D12/D3D12Device.h
@@ -13,7 +13,7 @@ class D3D12ComputePipelineState;
 class D3D12RootSignature;
 
 #define D3D12_PIPELINE_STATE_STREAM_ALIGNMENT	(sizeof(void*))
-#define D3D12_ENABLE_PIX_MARKERS				 1
+#define D3D12_ENABLE_PIX_MARKERS				 0
 
 /*
 * Function Typedefs

--- a/DXR-Project/D3D12/D3D12Resource.h
+++ b/DXR-Project/D3D12/D3D12Resource.h
@@ -25,6 +25,8 @@ public:
 	{
 		std::wstring WideName = ConvertToWide(Name);
 		NativeResource->SetName(WideName.c_str());
+
+		DebugName = Name;
 	}
 
 	FORCEINLINE ID3D12Resource* GetNativeResource() const
@@ -64,4 +66,6 @@ protected:
 	D3D12_RESOURCE_STATES		ResourceState;
 	D3D12_RESOURCE_DESC			Desc;
 	D3D12_GPU_VIRTUAL_ADDRESS	Address;
+
+	std::string DebugName;
 };

--- a/DXR-Project/Debug/Profiler.cpp
+++ b/DXR-Project/Debug/Profiler.cpp
@@ -1,0 +1,103 @@
+#include "Profiler.h"
+
+static void ImGui_PrintTiming(const Char* Text, Int64 Nanoseconds)
+{
+	constexpr Double MICROSECONDS		= 1000.0;
+	constexpr Double MILLISECONDS		= 1000.0 * 1000.0;
+	constexpr Double SECONDS			= 1000.0 * 1000.0 * 1000.0;
+	constexpr Double INV_MICROSECONDS	= 1.0 / MICROSECONDS;
+	constexpr Double INV_MILLISECONDS	= 1.0 / MILLISECONDS;
+	constexpr Double INV_SECONDS		= 1.0 / SECONDS;
+
+	ImGui::Text("%s: ", Text);
+
+	ImGui::NextColumn();
+
+	const Double NanosecondsFloat = Double(Nanoseconds);
+	if (NanosecondsFloat < MICROSECONDS)
+	{
+		ImGui::Text("%.4f ns", NanosecondsFloat);
+	}
+	else if (NanosecondsFloat < MICROSECONDS)
+	{
+		const Double Time = NanosecondsFloat * INV_MICROSECONDS;
+		ImGui::Text("%.4f qs", Time);
+	}
+	else if (NanosecondsFloat < SECONDS)
+	{
+		const Double Time = NanosecondsFloat * INV_MILLISECONDS;
+		ImGui::Text("%.4f ms", Time);
+	}
+	else
+	{
+		const Double Time = NanosecondsFloat * INV_SECONDS;
+		ImGui::Text("%.4f s", Time);
+	}
+
+	ImGui::NextColumn();
+}
+
+/*
+* Profiler
+*/
+
+Profiler::Profiler()
+	: Clock()
+	, FrameTime(0)
+	, Samples()
+{
+}
+
+void Profiler::BeginFrame()
+{
+	Clock.Tick();
+}
+
+void Profiler::EndFrame()
+{
+	const Int64 Delta = Clock.GetDeltaTime().AsNanoSeconds();
+	FrameTime.AddSample(Delta);
+}
+
+void Profiler::AddSample(const Char* Name, Int64 Nanoseconds)
+{
+	if (GlobalProfilerEnabled)
+	{
+		const std::string ScopeName = Name;
+	
+		auto Entry = Samples.find(ScopeName);
+		if (Entry != Samples.end())
+		{
+			Entry->second.AddSample(Nanoseconds);
+		}
+		else
+		{
+			Samples.insert(std::make_pair(ScopeName, Sample(Nanoseconds)));
+		}
+	}
+}
+
+void Profiler::DrawUI()
+{
+	if (GlobalProfilerEnabled && GlobalDrawProfiler)
+	{
+		ImGui::Text("CPU Timings:");
+		ImGui::Separator();
+
+		ImGui::Columns(2);
+		ImGui::SetColumnWidth(0, 260.0f);
+
+		ImGui_PrintTiming("FrameTime", FrameTime.CurrentSample);
+		ImGui::Columns(1);
+
+		ImGui::Separator();
+
+		ImGui::Columns(2);
+		for (auto& Sample : Samples)
+		{
+			const Char* Name = Sample.first.c_str();
+			ImGui_PrintTiming(Name, Sample.second.CurrentSample);
+		}
+		ImGui::Columns(1);
+	}
+}

--- a/DXR-Project/Debug/Profiler.h
+++ b/DXR-Project/Debug/Profiler.h
@@ -1,0 +1,89 @@
+#pragma once
+#include "Time/Clock.h"
+
+#include <unordered_map>
+
+#define ENABLE_PROFILER 1
+
+#if ENABLE_PROFILER
+	#define TRACE_SCOPE(Name)		ScopedTrace PREPROCESS_CONCAT(ScopedTrace_Line_, __LINE__)(GlobalProfiler, Name)
+	#define TRACE_FUNCTION_SCOPE()	TRACE_SCOPE(__FUNCTION_SIG__)
+#else
+	#define TRACE_SCOPE(Name)
+	#define TRACE_FUNCTION_SCOPE()
+#endif
+
+/*
+* Profiler
+*/
+
+class Profiler
+{
+	struct Sample
+	{
+		Sample() = default;
+
+		Sample(Int64 InCurrentSample = 0)
+			: CurrentSample(InCurrentSample)
+			, SampleCount(1)
+		{
+		}
+
+		FORCEINLINE void AddSample(Int64 NewSample)
+		{
+			CurrentSample = CurrentSample + (NewSample - CurrentSample) / SampleCount;
+			SampleCount++;
+		}
+
+		Int64 CurrentSample;
+		Int64 SampleCount;
+	};
+
+public:
+	Profiler();
+
+	void BeginFrame();
+	void EndFrame();
+
+	void AddSample(const Char* Name, Int64 Nanoseconds);
+
+	void DrawUI();
+
+private:
+	Clock Clock;
+	Sample FrameTime;
+
+	std::unordered_map<std::string, Sample> Samples;
+};
+
+/*
+* ScopedTrace
+*/
+
+struct ScopedTrace
+{
+public:
+	ScopedTrace(Profiler* InProfiler, const Char* InName)
+		: Profiler(InProfiler)
+		, Name(InName)
+		, Clock()
+	{
+		Clock.Tick();
+	}
+
+	~ScopedTrace()
+	{
+		Clock.Tick();
+		
+		if (Profiler)
+		{
+			const Int64 Nanoseconds = (UInt64)Clock.GetDeltaTime().AsNanoSeconds();
+			Profiler->AddSample(Name, Nanoseconds);
+		}
+	}
+
+private:
+	Profiler*	Profiler	= nullptr;
+	const Char*	Name		= nullptr;
+	Clock		Clock;
+};

--- a/DXR-Project/Editor/Editor.cpp
+++ b/DXR-Project/Editor/Editor.cpp
@@ -148,6 +148,7 @@ static void DrawMenu()
 			{
 				ImGui::MenuItem("Render Settings", NULL, &ShowRenderSettings);
 				ImGui::MenuItem("SceneGraph", NULL, &ShowSceneGraph);
+				ImGui::MenuItem("Profiler", NULL, &GlobalDrawProfiler);
 
 				ImGui::EndMenu();
 			}
@@ -312,38 +313,38 @@ static void DrawRenderSettings()
 	{
 		if (CurrentItem == 0)
 		{
-			Settings.ShadowMapWidth = 8192;
-			Settings.ShadowMapHeight = 8192;
+			Settings.ShadowMapWidth		= 8192;
+			Settings.ShadowMapHeight	= 8192;
 		}
 		else if (CurrentItem == 1)
 		{
-			Settings.ShadowMapWidth = 4096;
-			Settings.ShadowMapHeight = 4096;
+			Settings.ShadowMapWidth		= 4096;
+			Settings.ShadowMapHeight	= 4096;
 		}
 		else if (CurrentItem == 2)
 		{
-			Settings.ShadowMapWidth = 3072;
-			Settings.ShadowMapHeight = 3072;
+			Settings.ShadowMapWidth		= 3072;
+			Settings.ShadowMapHeight	= 3072;
 		}
 		else if (CurrentItem == 3)
 		{
-			Settings.ShadowMapWidth = 2048;
-			Settings.ShadowMapHeight = 2048;
+			Settings.ShadowMapWidth		= 2048;
+			Settings.ShadowMapHeight	= 2048;
 		}
 		else if (CurrentItem == 4)
 		{
-			Settings.ShadowMapWidth = 1024;
-			Settings.ShadowMapHeight = 1024;
+			Settings.ShadowMapWidth		= 1024;
+			Settings.ShadowMapHeight	= 1024;
 		}
 		else if (CurrentItem == 5)
 		{
-			Settings.ShadowMapWidth = 512;
-			Settings.ShadowMapHeight = 512;
+			Settings.ShadowMapWidth		= 512;
+			Settings.ShadowMapHeight	= 512;
 		}
 		else if (CurrentItem == 6)
 		{
-			Settings.ShadowMapWidth = 256;
-			Settings.ShadowMapHeight = 256;
+			Settings.ShadowMapWidth		= 256;
+			Settings.ShadowMapHeight	= 256;
 		}
 
 		GlobalRenderer->SetLightSettings(Settings);

--- a/DXR-Project/Engine/EngineGlobals.cpp
+++ b/DXR-Project/Engine/EngineGlobals.cpp
@@ -30,3 +30,12 @@ Bool GlobalFrustumCullEnabled	= true;
 Bool GlobalFXAAEnabled			= true;
 Bool GlobalRayTracingEnabled	= false;
 Bool GlobalSSAOEnabled			= true;
+
+/*
+* Debug
+*/
+
+class Profiler* GlobalProfiler = nullptr;
+
+Bool GlobalProfilerEnabled	= true;
+Bool GlobalDrawProfiler		= true;

--- a/DXR-Project/Engine/EngineGlobals.h
+++ b/DXR-Project/Engine/EngineGlobals.h
@@ -31,3 +31,12 @@ extern Bool GlobalFrustumCullEnabled;
 extern Bool GlobalFXAAEnabled;
 extern Bool GlobalRayTracingEnabled;
 extern Bool GlobalSSAOEnabled;
+
+/*
+* Debug
+*/
+
+extern class Profiler* GlobalProfiler;
+
+extern Bool GlobalProfilerEnabled;
+extern Bool GlobalDrawProfiler;

--- a/DXR-Project/Main.cpp
+++ b/DXR-Project/Main.cpp
@@ -2,6 +2,8 @@
 
 #include "Engine/EngineLoop.h"
 
+#include "Debug/Profiler.h"
+
 #include "Memory/Memory.h"
 
 #include <crtdbg.h>
@@ -35,6 +37,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdLine, 
 
 	while (EngineLoop::IsRunning())
 	{
+		TRACE_SCOPE("Tick");
+			
 		EngineLoop::PreTick();
 	
 		EngineLoop::Tick();

--- a/DXR-Project/Rendering/DebugUI.cpp
+++ b/DXR-Project/Rendering/DebugUI.cpp
@@ -1,5 +1,7 @@
 #include "DebugUI.h"
 
+#include "Debug/Profiler.h"
+
 #include "Application/Events/EventDispatcher.h"
 #include "Application/Generic/GenericCursor.h"
 #include "Application/Platform/PlatformApplication.h"
@@ -538,7 +540,7 @@ void DebugUI::Render(CommandList& CmdList)
 			case ImGuiMouseCursor_NotAllowed:	Cursor = GlobalCursors::NotAllowed;	break;
 			}
 			
-			GlobalPlatformApplication->SetCursor(GlobalCursors::Arrow.Get());
+			GlobalPlatformApplication->SetCursor(Cursor.Get());
 		}
 	}
 
@@ -553,12 +555,11 @@ void DebugUI::Render(CommandList& CmdList)
 	GlobalDrawFuncs.Clear();
 
 	// Draw DebugWindow with DebugStrings
-	constexpr Float Width = 300.0f;
-	ImGui::SetNextWindowPos(ImVec2(static_cast<Float>(CurrentWindowShape.Width - Width), 15.0f));
-	ImGui::SetNextWindowSize(ImVec2(Width, static_cast<Float>(CurrentWindowShape.Height)));
+	constexpr Float Width = 400.0f;
+	ImGui::SetNextWindowPos(ImVec2(static_cast<Float>(CurrentWindowShape.Width - Width), 18.0f));
+	ImGui::SetNextWindowSize(ImVec2(Width, 0.0f));
 
 	ImGui::Begin("DebugWindow", nullptr,
-		ImGuiWindowFlags_NoBackground	| 
 		ImGuiWindowFlags_NoTitleBar		| 
 		ImGuiWindowFlags_NoMove			| 
 		ImGuiWindowFlags_NoResize		| 
@@ -567,6 +568,7 @@ void DebugUI::Render(CommandList& CmdList)
 		ImGuiWindowFlags_NoSavedSettings);
 
 	ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));
+	ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.15f, 0.15f, 0.15f, 0.1f));
 
 	for (const std::string& Str : GlobalDebugStrings)
 	{
@@ -574,6 +576,11 @@ void DebugUI::Render(CommandList& CmdList)
 	}
 	GlobalDebugStrings.Clear();
 
+#if ENABLE_PROFILER
+	GlobalProfiler->DrawUI();
+#endif
+
+	ImGui::PopStyleColor();
 	ImGui::PopStyleColor();
 	ImGui::End();
 

--- a/DXR-Project/Rendering/Renderer.h
+++ b/DXR-Project/Rendering/Renderer.h
@@ -39,9 +39,6 @@ struct LightSettings
 class Renderer : public IEventHandler
 {
 public:
-	Renderer();
-	~Renderer();
-	
 	Bool Init();
 
 	void Tick(const Scene& CurrentScene);

--- a/DXR-Project/RenderingCore/RenderingAPI.cpp
+++ b/DXR-Project/RenderingCore/RenderingAPI.cpp
@@ -5,8 +5,6 @@
 #include "D3D12/D3D12RenderingAPI.h"
 #include "D3D12/D3D12ShaderCompiler.h"
 
-#define ENABLE_API_DEBUGGING 1
-
 /*
 * RenderingAPI
 */
@@ -28,7 +26,7 @@ bool RenderingAPI::Init(ERenderingAPI InRenderAPI)
 	}
 	else
 	{
-		LOG_ERROR("[RenderingAPI::Initialize] Invalid RenderingAPI enum");
+		LOG_ERROR("[RenderingAPI::Init] Invalid RenderingAPI enum");
 		
 		Debug::DebugBreak();
 		return false;

--- a/DXR-Project/RenderingCore/RenderingAPI.h
+++ b/DXR-Project/RenderingCore/RenderingAPI.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "GenericRenderingAPI.h"
 
+#define ENABLE_API_DEBUGGING 0
+
 /*
 * RenderingAPI
 */

--- a/DXR-Project/Windows/WindowsApplication.h
+++ b/DXR-Project/Windows/WindowsApplication.h
@@ -10,6 +10,26 @@ class ApplicationEventHandler;
 class WindowsCursor;
 
 /*
+* WindowsEvent
+*/
+
+struct WindowsEvent
+{
+	WindowsEvent(HWND InHwnd, UInt32 InMessage, WPARAM InwParam, LPARAM	InlParam)
+		: Hwnd(InHwnd)
+		, Message(InMessage)
+		, wParam(InwParam)
+		, lParam(InlParam)
+	{
+	}
+
+	HWND	Hwnd;
+	UInt32	Message;
+	WPARAM	wParam; 
+	LPARAM	lParam;
+};
+
+/*
 * WindowsApplication
 */
 
@@ -46,7 +66,8 @@ public:
 	virtual GenericCursor* MakeCursor() override final;
 
 	virtual Bool Init() override final;
-	
+	virtual void Tick() override final;
+
 	virtual void SetCursor(GenericCursor* Cursor)		override final;
 	virtual void SetActiveWindow(GenericWindow* Window)	override final;
 	virtual void SetCapture(GenericWindow* Window)		override final;
@@ -72,9 +93,11 @@ public:
 
 private:
 	HINSTANCE InstanceHandle = 0;
+
+	TArray<WindowsEvent> Events;
 	
-	TSharedRef<WindowsCursor>			CurrentCursor;
-	TArray<TSharedRef<WindowsWindow>>	Windows;
+	TSharedRef<WindowsCursor> CurrentCursor;
+	TArray<TSharedRef<WindowsWindow>> Windows;
 };
 
 extern WindowsApplication* GlobalWindowsApplication;

--- a/DXR-Project/Windows/WindowsConsoleOutput.h
+++ b/DXR-Project/Windows/WindowsConsoleOutput.h
@@ -14,10 +14,11 @@ public:
 	~WindowsConsoleOutput();
 
 	virtual void Print(const std::string& Message) override final;
+	
 	virtual void Clear() override final;
 
-	virtual void SetTitle(const std::string& Title) override final;
-	virtual void SetColor(EConsoleColor Color) override final;
+	virtual void SetTitle(const std::string& Title)	override final;
+	virtual void SetColor(EConsoleColor Color)		override final;
 
 	static GenericOutputDevice* Make();
 


### PR DESCRIPTION
* Added a simple CPU-Profiler for checking how long a function run. This uses a Moving average to keep the number of samples low. 
* PlatformApplication now stores events. This prevents GenericWindow from sending events at random points. This makes the engine more predictable.  