### PR TITLE
Fixed imgui in fullscreen mode

### DIFF
--- a/DXR-Project/D3D12/D3D12Viewport.cpp
+++ b/DXR-Project/D3D12/D3D12Viewport.cpp
@@ -84,7 +84,7 @@ Bool D3D12Viewport::Resize(UInt32 InWidth, UInt32 InHeight)
 {
 	// TODO: Make sure that we can release the old surfaces
 
-	if (InWidth != Width && InHeight != Height && InWidth > 0 && InHeight > 0)
+	if ((InWidth != Width || InHeight != Height) && InWidth > 0 && InHeight > 0)
 	{
 		BackBuffers.Clear();
 		BackBufferViews.Clear();

--- a/DXR-Project/Rendering/DebugUI.cpp
+++ b/DXR-Project/Rendering/DebugUI.cpp
@@ -74,6 +74,7 @@ bool DebugUI::Init()
 {
 	// Create context
 	IMGUI_CHECKVERSION();
+
 	GlobalImGuiState.Context = ImGui::CreateContext();
 	if (!GlobalImGuiState.Context)
 	{
@@ -497,11 +498,12 @@ void DebugUI::Render(CommandList& CmdList)
 	IO.DisplaySize				= ImVec2(Float(CurrentWindowShape.Width), Float(CurrentWindowShape.Height));
 	IO.DisplayFramebufferScale	= ImVec2(1.0f, 1.0f);
 
+
 	// Get Mouseposition
 	Int32 x = 0;
 	Int32 y = 0;
 	GlobalPlatformApplication->GetCursorPos(Window, x, y);
-
+	
 	IO.MousePos = ImVec2(static_cast<Float>(x), static_cast<Float>(y));
 
 	// Check modifer keys

--- a/DXR-Project/Windows/WindowsApplication.cpp
+++ b/DXR-Project/Windows/WindowsApplication.cpp
@@ -33,6 +33,7 @@ WindowsApplication::WindowsApplication(HINSTANCE InInstanceHandle)
 
 WindowsApplication::~WindowsApplication()
 {
+	Windows.Clear();
 	GlobalWindowsApplication = nullptr;
 }
 
@@ -82,10 +83,12 @@ void WindowsApplication::Tick()
 			{
 				if (MessageWindow)
 				{
-					const UInt16 Width = LOWORD(lParam);
-					const UInt16 Height = HIWORD(lParam);
+					const UInt16 Width	= LOWORD(lParam);
+					const UInt16 Height	= HIWORD(lParam);
 
 					EventHandler->OnWindowResized(MessageWindow, Width, Height);
+
+					LOG_INFO("Window Resize(" + std::to_string(Width) + ", " + std::to_string(Height) + ")");
 				}
 
 				break;
@@ -94,8 +97,8 @@ void WindowsApplication::Tick()
 			case WM_SYSKEYUP:
 			case WM_KEYUP:
 			{
-				const UInt32	ScanCode = static_cast<UInt32>(HIWORD(lParam) & SCAN_CODE_MASK);
-				const EKey		Key = Input::ConvertFromScanCode(ScanCode);
+				const UInt32 ScanCode	= static_cast<UInt32>(HIWORD(lParam) & SCAN_CODE_MASK);
+				const EKey Key			= Input::ConvertFromScanCode(ScanCode);
 				EventHandler->OnKeyReleased(Key, GetModifierKeyState());
 				break;
 			}
@@ -103,8 +106,8 @@ void WindowsApplication::Tick()
 			case WM_SYSKEYDOWN:
 			case WM_KEYDOWN:
 			{
-				const UInt32	ScanCode = static_cast<UInt32>(HIWORD(lParam) & SCAN_CODE_MASK);
-				const EKey		Key = Input::ConvertFromScanCode(ScanCode);
+				const UInt32 ScanCode	= static_cast<UInt32>(HIWORD(lParam) & SCAN_CODE_MASK);
+				const EKey Key			= Input::ConvertFromScanCode(ScanCode);
 				EventHandler->OnKeyPressed(Key, GetModifierKeyState());
 				break;
 			}


### PR DESCRIPTION
* The back buffer did not resize if the width or the height was the same, now, if any of these parameters has changed the Viewport gets resized. Basically went from
`
if (NewWidth != CurrentWidth && NewHeight != CurrentHeight)
{
// Do resize
}
`
to
`
if (NewWidth != CurrentWidth || NewHeight != CurrentHeight)
{
// Do resize
}
`